### PR TITLE
Using `RemoteRoot` in `LocalPath` instead of `URL.Host`

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -62,7 +62,7 @@ func (b *Broker) FetchRemoteEntries() ([]*Entry, error) {
 
 func (b *Broker) LocalPath(e *Entry) string {
 	extension := ".md" // TODO regard re.ContentType
-	return filepath.Join(b.LocalRoot, e.URL.Host, e.URL.Path+extension)
+	return filepath.Join(b.LocalRoot, b.RemoteRoot, e.URL.Path+extension)
 }
 
 func (b *Broker) StoreFresh(e *Entry, path string) (bool, error) {


### PR DESCRIPTION
It is incompatible change, but reasonable change for the following reason.

- this change affect only few users who use original domain
- when using original domain, blogsync doesn't work fully currently
  - e.g. `blogsync post` doesn't work, because blogsync can't resolve remote root from the path name.
- When using `URL.Host` as a `LocalPath`, if a user changes the domain name, local directory name also changes. It is inconvenient behaviour if the directory is under version control.
