### PR TITLE
if there is not config.yml in HOME, look up current dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,10 @@ func loadConfigFile() *Config {
 	dieIf(err)
 
 	f, err := os.Open(filepath.Join(home, ".config", "blogsync", "config.yaml"))
+	if err != nil {
+		pwd, _ := os.Getwd()
+		f, err = os.Open(filepath.Join(pwd, ".config", "blogsync", "config.yaml"))
+	}
 	dieIf(err)
 
 	conf, err := LoadConfig(f)


### PR DESCRIPTION
githubで記事を管理したい時などカレントディレクトリの `config.yaml` をみてほしい。

懸念点
------
- 公開リポジトリに `config.yaml` 含めるとセキュリティ上よくない 
- この手のツールはカレントディレクトリ → $HOME の順番で設定を見に行く事が多い

他の案
------
- 引数で `config.yaml` の位置を指定できる
  - 毎回指定するのがだるい

沙汰を