### PR TITLE
Add list command

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,13 +202,26 @@ var commandPost = cli.Command{
 var commandList = cli.Command{
 	Name:  "list",
 	Usage: "List local blogs",
+	Flags: []cli.Flag{
+		cli.BoolFlag{Name: "full-path, p", Usage: "Print full paths"},
+	},
 	Action: func(c *cli.Context) error {
 		conf, err := loadConfiguration()
 		if err != nil {
 			return err
 		}
+		fullPath := c.Bool("full-path")
 		for remoteRoot := range conf.Blogs {
-			fmt.Println(remoteRoot)
+			if fullPath {
+				blogConfig := conf.Get(remoteRoot)
+				if blogConfig.OmitDomain == nil || !*blogConfig.OmitDomain {
+					fmt.Println(filepath.Join(blogConfig.LocalRoot, blogConfig.RemoteRoot))
+				} else {
+					fmt.Println(blogConfig.LocalRoot)
+				}
+			} else {
+				fmt.Println(remoteRoot)
+			}
 		}
 		return nil
 	},

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 		commandPull,
 		commandPush,
 		commandPost,
+		commandList,
 	}
 	app.Version = fmt.Sprintf("%s (%s)", version, revision)
 	err := app.Run(os.Args)
@@ -193,6 +194,21 @@ var commandPost = cli.Command{
 		err = b.PostEntry(entry)
 		if err != nil {
 			return err
+		}
+		return nil
+	},
+}
+
+var commandList = cli.Command{
+	Name:  "list",
+	Usage: "List local blogs",
+	Action: func(c *cli.Context) error {
+		conf, err := loadConfiguration()
+		if err != nil {
+			return err
+		}
+		for remoteRoot := range conf.Blogs {
+			fmt.Println(remoteRoot)
 		}
 		return nil
 	},


### PR DESCRIPTION
This PR close #28.

`blogsync list` output blogs in local to stdout.

For example, if `config.yaml` is:
```yaml
autopp.hatenablog.com:
  username: autopp

autopp-tech.hatenablog.com:
  username: autopp
  local_root: /Users/autopp/techblog
  omit_domain: true

default:
  local_root: /Users/autopp/hatenablog
```

`blogsync list` outputs:
```
autopp.hatenablog.com
autopp-tech.hatenablog.com
```

and when `-p` or `--full-path` is given, its outputs:
```
/Users/autopp/hatenablog/autopp.hatenablog.com
/Users/autopp/techblog
```

The command name and option are inspired by [ghq](https://github.com/motemen/ghq).
