### PR TITLE
fix path of golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ deps:
 	dep ensure
 
 devel-deps: deps
-	go get ${u} github.com/golang/lint/golint \
+	go get ${u} golang.org/x/lint/golint \
 	  github.com/haya14busa/goverage          \
 	  github.com/mattn/goveralls              \
 	  github.com/motemen/gobump               \


### PR DESCRIPTION
Fix #30.

This PR changed import path of golint to `golang.org/x/lint/golint`.

https://github.com/golang/lint/commit/ead987a65e5c7e053cf9633f9eac1f734f6b4fe3
https://github.com/golang/lint/issues/415