### PR TITLE
Fix: Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ blogsync
 
 https://github.com/motemen/blogsync/releases から実行ファイルを直接取得できます。
 
-HEADを使いたい場合は `go get github.com/motemne/blogsync` してください。
+HEADを使いたい場合は `go get github.com/motemen/blogsync` してください。
 
 ## Usage
 


### PR DESCRIPTION
Thanks for your great project!

I just failed to run `go get github.com/motemne/blogsync` due to a typo probably.