### PR TITLE
remove github.com/mitchellh/go-homedir dependency

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -6,17 +6,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 func TestLoadConfigFiles(t *testing.T) {
-	orig := homedir.DisableCache
-	homedir.DisableCache = true
-	defer func() {
-		homedir.DisableCache = orig
-	}()
-
 	setup := func(t *testing.T, localConf, globalConf *string) (string, func()) {
 		tempdir, err := ioutil.TempDir("", "blogsync-test")
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/motemen/blogsync
 
 require (
 	github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920 // indirect
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/motemen/go-colorine v0.0.0-20180816141035-45d19169413a
 	github.com/motemen/go-loghttp v0.0.0-20170804080138-974ac5ceac27
 	github.com/motemen/go-nuts v0.0.0-20180315145558-42c35bdb11c2 // indirect
 	github.com/motemen/go-wsse v0.0.0-20141201105324-13a083a10e32
+	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.20.0
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920 h1:d/cVoZOrJPJHKH1NdeUjyVAWKp4OpOT+Q+6T1sH7jeU=
 github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/motemen/go-colorine v0.0.0-20180816141035-45d19169413a h1:CONqI/36EjYzkAzrMD0UWuL/lRDr7UdoID4fDGke+Yc=
 github.com/motemen/go-colorine v0.0.0-20180816141035-45d19169413a/go.mod h1:PU2urRC7j30rrabSyp1MGGhyoiWSninPD8ckjzBSgkU=
 github.com/motemen/go-loghttp v0.0.0-20170804080138-974ac5ceac27 h1:uAI3rnOT1OSSY4PUtI/M1orb3q0ewkovwd3wr8xSno4=
@@ -10,6 +10,11 @@ github.com/motemen/go-nuts v0.0.0-20180315145558-42c35bdb11c2 h1:gfo7RLzXaBdNShd
 github.com/motemen/go-nuts v0.0.0-20180315145558-42c35bdb11c2/go.mod h1:vfh/NPxHgDwggXit20W1llPsXcz39xJ7I8vo7kVrOCk=
 github.com/motemen/go-wsse v0.0.0-20141201105324-13a083a10e32 h1:6QdHev5nNIr8b6LYnwo50ojsfgoCT0yOEEluTNW8f3s=
 github.com/motemen/go-wsse v0.0.0-20141201105324-13a083a10e32/go.mod h1:o5JZHZuxn62HNeZEAUiu/F6rm7xEL1RSmM8EQREgc+8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/urfave/cli"
 )
 
@@ -57,7 +56,7 @@ func loadConfigFiles(pwd string) (*config, error) {
 		return nil, err
 	}
 
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil && conf == nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now that we can use os.UserHomeDir in Go 1.12+, I removed the library dependency to github.com/mitchellh/go-homedir.